### PR TITLE
Handle Catching And Replying With Error From Any Step In Handler Prom…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,12 +185,10 @@ function handler(request, reply) {
           if (disposition) {
             response.header('Content-Disposition', disposition);
           }
-        })
-        .catch((err) => {
-          reply(err);
         });
     }
-  );
+  )
+    .catch((err) => reply(err));
 }
 
 function register(server, options, next) {


### PR DESCRIPTION
…ise Chain

When an error is thrown from getKey or getFilename in handler(), the error is uncaught which triggers a 500 vs whatever was thrown.

In getKey, if we can't find the key on S3 we throw a Boom.notFound but the error reported is actually a 500 since it's not caught and replied in the handler. 
