### PR TITLE
handle undefined key param correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,12 +112,20 @@ function getBucket(request) {
 function getKey(request) {
   const { key } = request.route.settings.plugins.s3;
 
-  if (!key || _.isString(key)) {
+  if (_.isString(key)) {
     if (request.params.path) {
       return Promise.resolve(path.join(key, request.params.path));
     }
 
     return Promise.resolve(key);
+  }
+
+  if (!key) {
+    if (request.params.path) {
+      return Promise.resolve(request.params.path);
+    } else {
+      return Promise.resolve('');
+    }
   }
 
   return Promise.resolve(key(request));


### PR DESCRIPTION
This fixes `getKey()` for the case of undefined `key` by ignoring the `key` and resolving with `request.params.path` or an empty string.

Otherwise not defining `key` results in the s3 handler options results in an error.
An alternative solution would be to allow empty string as `key` value by adding `Joi.allow('')` to the alternatives for `key`. As the `key` is optional in the Joi validation, I think it should handle the case where it's `undefined` correctly, thus the implementation in this PR.

If I miss something, please let me know.
